### PR TITLE
Use metrics service config file in scala-maven-plugin - hydra/v3.2.2

### DIFF
--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -220,7 +220,10 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
         }
 
         proc.addSysProp("triplequote.dashboard.client.metricsDirectory", hydraMetricsDirectory);
-        proc.addSysProp("triplequote.dashboard.client.serverUrl", hydraDashboardServerUrl);
+        Path hydraMetricsConfigFile = Paths.get(hydraMetricsDirectory).resolve("config").resolve("metrics-service.conf");
+        if (hydraMetricsConfigFile.toFile().isFile()) {
+            proc.addSysProp("config.file", hydraMetricsConfigFile.toString());
+        }
         proc.spawn(false);
     }
 

--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -206,16 +206,9 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     protected String hydraMetricsDirectory = "";
 
     /**
-     * Where to upload metrics files
-     *
-     * @parameter property="hydraDashboardServerUrl" default-value="http://localhost:3333"
-     */
-    protected String hydraDashboardServerUrl = "";
-
-    /**
      * Version of the MetricsService uploader
      *
-     * @parameter property="hydraMetricsServiceVersion" default-value="0.11.0"
+     * @parameter property="hydraMetricsServiceVersion" default-value="1.1.0-SNAPSHOT"
      */
     protected String hydraMetricsServiceVersion = "";
 


### PR DESCRIPTION
Update hydra integration of scala-maven-plugin to match upstream metrics
service configuration policy, i.e. use a config file per metrics folder.

I didn't find the code related to the metrics service on branch hydra/v3.3.1. What is the status there?

PR is related to issue https://github.com/triplequote/dashboard/issues/36

I've managed to start the metrics service with the plugin on a test project, but hydra didn't seem to drop any metrics in the metrics folder. As a side note, the maven docs need some corrections. I'll create a PR on hydra for that.
