### PR TITLE
Bump default version to release 1.1.0 of the metrics service

### DIFF
--- a/src/main/java/scala_maven/ScalaMojoSupport.java
+++ b/src/main/java/scala_maven/ScalaMojoSupport.java
@@ -208,7 +208,7 @@ public abstract class ScalaMojoSupport extends AbstractMojo {
     /**
      * Version of the MetricsService uploader
      *
-     * @parameter property="hydraMetricsServiceVersion" default-value="1.1.0-SNAPSHOT"
+     * @parameter property="hydraMetricsServiceVersion" default-value="1.1.0"
      */
     protected String hydraMetricsServiceVersion = "";
 


### PR DESCRIPTION
This should be applied before releasing.

See issue https://github.com/triplequote/dashboard/issues/36