### PR TITLE
Inform the user when metrics service config is missing

### DIFF
--- a/src/main/java/scala_maven/ScalaCompilerSupport.java
+++ b/src/main/java/scala_maven/ScalaCompilerSupport.java
@@ -220,9 +220,12 @@ public abstract class ScalaCompilerSupport extends ScalaSourceMojoSupport {
         }
 
         proc.addSysProp("triplequote.dashboard.client.metricsDirectory", hydraMetricsDirectory);
-        Path hydraMetricsConfigFile = Paths.get(hydraMetricsDirectory).resolve("config").resolve("metrics-service.conf");
+        Path hydraMetricsConfigFile = Paths.get(hydraMetricsDirectory).resolve("config").resolve("metrics-service.conf").toAbsolutePath();
         if (hydraMetricsConfigFile.toFile().isFile()) {
             proc.addSysProp("config.file", hydraMetricsConfigFile.toString());
+        } else {
+            String configFileMissing = String.format("No metrics service config file found at %s - see https://docs.triplequote.com/dashboard/metrics-service/", hydraMetricsConfigFile);
+            getLog().info(configFileMissing);
         }
         proc.spawn(false);
     }


### PR DESCRIPTION
Here is some sample output:

```
[INFO] --- scala-maven-plugin:3.2.2-hydra08-SNAPSHOT:compile (default) @ scala-maven-example ---
[INFO] No metrics service config file found at /home/cipi/.triplequote/metrics/config/metrics-service.conf. See https://docs.triplequote.com/dashboard/metrics-service/
[INFO] /home/cipi/src/triplequote/test-projects/scala-maven-example/src/main/java:-1: info: compiling
[INFO] /home/cipi/src/triplequote/test-projects/scala-maven-example/src/main/scala:-1: info: compiling
[INFO] Compiling 2 source files to /home/cipi/src/triplequote/test-projects/scala-maven-example/target/classes at 1534777160944
[INFO] [-sourcepath, /home/cipi/src/triplequote/test-projects/scala-maven-example/src/main/java:/home/cipi/src/triplequote/test-projects/scala-maven-example/src/main/scala, -cpus, 4, -YhydraStore, /home/cipi/src/triplequote/test-projects/scala-maven-example/.hydra/maven/scala-maven-example/compile, -YhydraTag, scala-maven-example/compile, -YtimingsFile, /home/cipi/src/triplequote/test-projects/scala-maven-example/.hydra/maven/timings.csv, -YrootDirectory, /home/cipi/src/triplequote/test-projects/scala-maven-example, -Ymetrics, -YhydraMetricsDirectory, /home/cipi/.triplequote/metrics]
[INFO] [worker 0]: License will expire in 11 days.
[INFO] Using 1 Hydra worker to compile Scala sources.
[INFO] prepare-compile in 0 s
[INFO] compile in 6 s
```